### PR TITLE
Adds Yaskawa Sigma 5 Encoder module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COMMON_VHDL := $(patsubst %, src/%, IDROMConst.vhd \
     testrom.vhd threephasepwm.vhd timestamp.vhd uartr8.vhd uartr.vhd uartx8.vhd \
     uartx.vhd ubrategen.vhd usbram.vhd usbrom.vhd watchdog.vhd wordpr.vhd \
     wordrb.vhd fixicap.vhd d16w.vhd etherhm2.vhd \
-    parity.vhd decodedstrobe2.vhd \
+    parity.vhd decodedstrobe2.vhd sigma5enc.vhd \
     hostmot2.vhd)
 
 TOP_i20 := src/Top9030HostMot2.vhd

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -68,6 +68,7 @@ common_vhdl = [
     'qcounteratesk.vhd',
     'scalercounter.vhd',
     'scalertimer.vhd',
+    'sigma5enc.vhd',
     'simplespi8.vhd',
     'simplespix.vhd',
     'simplessi.vhd',

--- a/scripts/iselib.py
+++ b/scripts/iselib.py
@@ -63,7 +63,7 @@ def use_ise(iseversions):
             settings_sh = localsettings
             break
 
-        files = glob.glob('/opt/Xilinx/%s/*/settings32.sh' % ise)
+        files = glob.glob('/opt/Xilinx/%s/*/settings64.sh' % ise)
         if len(files) > 1:
             print "multiple settings files found!", files
             raise SystemExit, 1
@@ -71,7 +71,7 @@ def use_ise(iseversions):
             settings_sh = files[0]
             break
 
-        files = glob.glob('/opt/Xilinx/%s.*/*/settings32.sh' % ise)
+        files = glob.glob('/opt/Xilinx/%s.*/*/settings64.sh' % ise)
         if len(files) == 1:
             settings_sh = files[0]
             break

--- a/src/IDROMConst.vhd
+++ b/src/IDROMConst.vhd
@@ -286,7 +286,7 @@ package IDROMConst is
 	constant PktUARTRModeRegAddr : std_logic_vector(7 downto 0) := x"67";
 	constant PktUARTRNumRegs : std_logic_vector(7 downto 0) := x"04";
 	constant PktUARTRMPBitMask : std_logic_vector(31 downto 0) := x"0000000F";
-
+	
 	constant SSSIDataAddr0 : std_logic_vector(7 downto 0) := x"68";
 	constant SSSIDataAddr1 : std_logic_vector(7 downto 0) := x"69";
 	constant SSSIControlAddr : std_logic_vector(7 downto 0) := x"6A";
@@ -334,6 +334,20 @@ package IDROMConst is
 	constant TranslateNumRegs : std_logic_vector(7 downto 0) := x"04";
 	constant TranslateMPBitMask : std_logic_vector(31 downto 0) := x"00000000";
 
+
+
+	--Sigma5 encoder - Interfaces with Yaskawa Sigama V encoders
+	constant Sigma5EncControlAddr  : std_logic_vector(7 downto 0)  := x"80";
+    constant Sigma5EncRx0Addr      : std_logic_vector(7 downto 0)  := X"81";
+    constant Sigma5EncRx1Addr      : std_logic_vector(7 downto 0)  := X"82";
+    constant Sigma5EncRx2Addr      : std_logic_vector(7 downto 0)  := X"83";
+    constant Sigma5EncStatusAddr   : std_logic_vector(7 downto 0)  := X"84";
+	constant Sigma5EncNumRegs      : std_logic_vector(7 downto 0)  := x"05";
+	constant Sigma5EncMPBitMask    : std_logic_vector(31 downto 0) := x"0000001F";
+
+
+	
+	
 	constant ClockLow20: integer :=  33333333;  		-- 5I20/4I65 low speed clock
 	constant ClockLow22: integer :=  48000000;		-- 5I22/5I23 low speed clock
 	constant ClockLow23: integer :=  48000000;		-- 5I22/5I23 low speed clock
@@ -621,6 +635,13 @@ package IDROMConst is
 	constant ScalerCounterTag : std_logic_vector(7 downto 0)   	:= x"1D";
 		constant ScalerCounterInA : std_logic_vector(7 downto 0)	:= x"01";
 		constant ScalerCounterInB : std_logic_vector(7 downto 0)	:= x"02";
+		
+		
+	constant Sigma5EncTag         : std_logic_vector(7 downto 0)      := x"1F";
+		constant Sigma5EncTxdataPin   : std_logic_vector(7 downto 0)  := x"81";
+		constant Sigma5EncRxdataPin   : std_logic_vector(7 downto 0)  := x"02";
+        constant Sigma5EncTxenPin : std_logic_vector(7 downto 0)      := x"83";
+		
 		
 	constant LIOPortTag : std_logic_vector(7 downto 0) := x"40";
 

--- a/src/IDROMConst.vhd
+++ b/src/IDROMConst.vhd
@@ -337,11 +337,11 @@ package IDROMConst is
 
 
 	--Sigma5 encoder - Interfaces with Yaskawa Sigama V encoders
-	constant Sigma5EncControlAddr  : std_logic_vector(7 downto 0)  := x"80";
-    constant Sigma5EncRx0Addr      : std_logic_vector(7 downto 0)  := X"81";
-    constant Sigma5EncRx1Addr      : std_logic_vector(7 downto 0)  := X"82";
-    constant Sigma5EncRx2Addr      : std_logic_vector(7 downto 0)  := X"83";
-    constant Sigma5EncStatusAddr   : std_logic_vector(7 downto 0)  := X"84";
+	constant Sigma5EncControlAddr  : std_logic_vector(7 downto 0)  := x"E0";
+    constant Sigma5EncRx0Addr      : std_logic_vector(7 downto 0)  := X"E1";
+    constant Sigma5EncRx1Addr      : std_logic_vector(7 downto 0)  := X"E2";
+    constant Sigma5EncRx2Addr      : std_logic_vector(7 downto 0)  := X"E3";
+    constant Sigma5EncStatusAddr   : std_logic_vector(7 downto 0)  := X"E4";
 	constant Sigma5EncNumRegs      : std_logic_vector(7 downto 0)  := x"05";
 	constant Sigma5EncMPBitMask    : std_logic_vector(31 downto 0) := x"0000001F";
 

--- a/src/PIN_7I74_SIGMA_34.vhd
+++ b/src/PIN_7I74_SIGMA_34.vhd
@@ -1,0 +1,164 @@
+library IEEE;
+use IEEE.std_logic_1164.all;  -- defines std_logic types
+use IEEE.STD_LOGIC_ARITH.ALL;
+use IEEE.STD_LOGIC_UNSIGNED.ALL;
+
+-- Copyright (C) 2007, Peter C. Wallace, Mesa Electronics
+-- http://www.mesanet.com
+--
+-- This program is is licensed under a disjunctive dual license giving you
+-- the choice of one of the two following sets of free software/open source
+-- licensing terms:
+--
+--    * GNU General Public License (GPL), version 2.0 or later
+--    * 3-clause BSD License
+-- 
+--
+-- The GNU GPL License:
+-- 
+--     This program is free software; you can redistribute it and/or modify
+--     it under the terms of the GNU General Public License as published by
+--     the Free Software Foundation; either version 2 of the License, or
+--     (at your option) any later version.
+-- 
+--     This program is distributed in the hope that it will be useful,
+--     but WITHOUT ANY WARRANTY; without even the implied warranty of
+--     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--     GNU General Public License for more details.
+-- 
+--     You should have received a copy of the GNU General Public License
+--     along with this program; if not, write to the Free Software
+--     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+-- 
+-- 
+-- The 3-clause BSD License:
+-- 
+--     Redistribution and use in source and binary forms, with or without
+--     modification, are permitted provided that the following conditions
+--     are met:
+-- 
+--   * Redistributions of source code must retain the above copyright
+--     notice, this list of conditions and the following disclaimer.
+-- 
+--   * Redistributions in binary form must reproduce the above
+--     copyright notice, this list of conditions and the following
+--     disclaimer in the documentation and/or other materials
+--     provided with the distribution.
+-- 
+--   * Neither the name of Mesa Electronics nor the names of its
+--     contributors may be used to endorse or promote products
+--     derived from this software without specific prior written
+--     permission.
+-- 
+-- 
+-- Disclaimer:
+-- 
+--     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+--     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+--     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+--     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--     COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+--     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+--     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+--     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+--     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--     POSSIBILITY OF SUCH DAMAGE.
+-- 
+
+use work.IDROMConst.all;
+
+package PIN_7I74_Sigma_34 is
+	constant ModuleID : ModuleIDType :=( 
+	    (HM2DPLLTag,	x"00",	ClockLowTag,	    x"01",	HM2DPLLBaseRateAddr&PadT,	    HM2DPLLNumRegs,		    x"00",	HM2DPLLMPBitMask),
+	    (WatchDogTag,	x"00",	ClockLowTag,		x"01",	WatchDogTimeAddr&PadT,			WatchDogNumRegs,        x"00",	WatchDogMPBitMask),
+		(IOPortTag,		x"00",	ClockLowTag,		x"02",	PortAddr&PadT,					IOPortNumRegs,	        x"00",	IOPortMPBitMask),
+        (SSerialTag,    x"00",  ClockLowTag,        x"01",  SSerialCommandAddr&PadT,        SSerialNumRegs,         x"10",  SSerialMPBitMask),
+		(Sigma5EncTag,  x"00",	ClockLowTag,	 	x"04",	Sigma5EncControlAddr&PadT,	    Sigma5EncNumRegs,       x"00",	Sigma5EncMPBitMask),
+		(LEDTag,		x"00",	ClockLowTag,		x"01",	LEDAddr&PadT,					LEDNumRegs,				x"00",	LEDMPBitMask),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000"),
+		(NullTag,		x"00",	NullTag,			x"00",	NullAddr&PadT,					x"00",					x"00",	x"00000000")
+		);
+		
+	
+	constant PinDesc : PinDescType :=(
+-- 	Base func  sec unit sec func 	 sec pin		
+		IOPortTag & x"00" & SSerialTag & SSerialRX0Pin,    		-- I/O 00	-- external DB25
+		IOPortTag & x"00" & Sigma5EncTag & Sigma5EncRxdataPin,	-- I/O 01
+		IOPortTag & x"00" & SSerialTag & SSerialRX1Pin,   		-- I/O 02
+		IOPortTag & x"01" & Sigma5EncTag & Sigma5EncRxdataPin, 	-- I/O 03
+		IOPortTag & x"00" & SSerialTag & SSerialTX0Pin,         -- I/O 04
+		IOPortTag & x"00" & Sigma5EncTag & Sigma5EncTxdataPin, 	-- I/O 05
+		IOPortTag & x"00" & SSerialTag & SSerialTX1Pin,  		-- I/O 06
+		IOPortTag & x"01" & Sigma5EncTag & Sigma5EncTxdataPin,	-- I/O 07
+		IOPortTag & x"00" & SSerialTag & SSerialRX2Pin,  		-- I/O 08
+		IOPortTag & x"02" & Sigma5EncTag & Sigma5EncRxdataPin, 	-- I/O 09
+		IOPortTag & x"00" & SSerialTag & SSerialRX3Pin,        	-- I/O 10
+		IOPortTag & x"03" & Sigma5EncTag & Sigma5EncRxdataPin,	-- I/O 11
+		IOPortTag & x"00" & SSerialTag & SSerialTX2Pin,			-- I/O 12
+		IOPortTag & x"02" & Sigma5EncTag & Sigma5EncTxdataPin,  -- I/O 13
+		IOPortTag & x"00" & SSerialTag & SSerialTX3Pin, 		-- I/O 14
+		IOPortTag & x"03" & Sigma5EncTag & Sigma5EncTxdataPin, 	-- I/O 15
+		IOPortTag & x"00" & Sigma5EncTag & Sigma5EncTxenPin,    -- I/O 16
+		IOPortTag & x"00" & NullTag & x"00",              		-- I/O 17	-- internal 26 pin header
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 18
+		IOPortTag & x"00" & NullTag & x"00",          			-- I/O 19
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 20
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 21
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 22
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 23
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 24
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 25
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 26
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 27
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 28
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 29
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 30
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 31
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 32
+		IOPortTag & x"00" & NullTag & x"00",					-- I/O 33
+
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin, -- added for 34 pin 5I25
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+
+
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin, -- added for IDROM v3
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+					
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin);
+
+end package PIN_7I74_Sigma_34;

--- a/src/idrom_tools.vhd
+++ b/src/idrom_tools.vhd
@@ -168,6 +168,7 @@ begin
     if(tag = SSerialTag)    then return "SSerial"; end if;
     if(tag = PktUARTTTag)    then return "PktUARTTx"; end if;
     if(tag = PktUARTRTag)    then return "PktUARTrx"; end if;
+    if(tag = Sigma5EncTag)     then return "Sigma5Enc"; end if;
     return "unknown";
 end;
 
@@ -250,6 +251,11 @@ begin
     elsif(tag = PktUARTRTag) then
         if(pin = PktURDataPin)       then return "Packet Serial Receive (in)";
         end if;
+    elsif(tag = Sigma5EncTag) then
+	if(pin = Sigma5EncTxdataPin)      then  return "Sigma5 Encoder Txdata";
+	elsif(pin = Sigma5EncRxdataPin)   then  return "Sigma5 Encoder Rxdata";
+    elsif(pin = Sigma5EncTxenPin)   then  return "Sigma5 Encoder Tx Enable";
+	end if;
     end if;
     return "???";
 end function;

--- a/src/sigma5enc.vhd
+++ b/src/sigma5enc.vhd
@@ -1,0 +1,475 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+use IEEE.STD_LOGIC_UNSIGNED.ALL;
+use IEEE.MATH_REAL.ALL;
+--
+-- Copyright (C) 2009, Peter C. Wallace, Mesa Electronics
+-- Copyright (C) 2020, Curtis E Dutton, Dutton Industrial
+-- http://www.mesanet.com
+--
+-- This program is is licensed under a disjunctive dual license giving you
+-- the choice of one of the two following sets of free software/open source
+-- licensing terms:
+--
+--    * GNU General Public License (GPL), version 2.0 or later
+--    * 3-clause BSD License
+-- 
+--
+-- The GNU GPL License:
+-- 
+--     This program is free software; you can redistribute it and/or modify
+--     it under the terms of the GNU General Public License as published by
+--     the Free Software Foundation; either version 2 of the License, or
+--     (at your option) any later version.
+-- 
+--     This program is distributed in the hope that it will be useful,
+--     but WITHOUT ANY WARRANTY; without even the implied warranty of
+--     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--     GNU General Public License for more details.
+-- 
+--     You should have received a copy of the GNU General Public License
+--     along with this program; if not, write to the Free Software
+--     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+-- 
+-- 
+-- The 3-clause BSD License:
+-- 
+--     Redistribution and use in source and binary forms, with or without
+--     modification, are permitted provided that the following conditions
+--     are met:
+-- 
+--         * Redistributions of source code must retain the above copyright
+--           notice, this list of conditions and the following disclaimer.
+-- 
+--         * Redistributions in binary form must reproduce the above
+--           copyright notice, this list of conditions and the following
+--           disclaimer in the documentation and/or other materials
+--           provided with the distribution.
+-- 
+--         * Neither the name of Mesa Electronics nor the names of its
+--           contributors may be used to endorse or promote products
+--           derived from this software without specific prior written
+--           permission.
+-- 
+-- 
+-- Disclaimer:
+-- 
+--     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+--     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+--     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+--     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--     COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+--     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+--     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+--     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+--     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--     POSSIBILITY OF SUCH DAMAGE.
+-- 
+
+
+--The Sigma5Enc component transmits
+--manchester encoded data then listens for a response from a Sigma V encoders
+entity Sigma5Enc is
+    generic (
+        buswidth : integer
+        );
+    Port (  
+        clkmed : in std_logic;
+        clklow : in std_logic;
+        ibus : in std_logic_vector(buswidth-1 downto 0);   --host bus data in
+        obus : out std_logic_vector(buswidth-1 downto 0);  --host bus data outa
+        timers : in std_logic_vector(4 downto 0); --dpll timers
+        bus_load_control : in std_logic;  --load transmit from control register
+        bus_store_rx0 : in std_logic;
+        bus_store_rx1 : in std_logic;
+        bus_store_rx2 : in std_logic;
+        bus_store_status : in std_logic;
+        txdata : out std_logic; --transmit data
+        txen : out std_logic; --transmit enable
+        rxdata : in std_logic  --receive data
+        
+    );
+end Sigma5Enc;
+
+architecture Behavioral of Sigma5Enc is
+
+    constant bitrate : std_logic_vector(7 downto 0) := x"0C"; --100MHZ / 12 = 8333333 MHZ
+
+    signal enable : std_logic; --when true transmit cycle is enabled
+    signal transmitting : std_logic;  --controls transmit recieve cycle
+    signal transmit : std_logic; --start a transmit cycle
+    signal transmit_prev : std_logic;
+
+    signal rx_ok : std_logic;
+    signal busy : std_logic;
+    signal any_data_received : std_logic;
+
+    --rx manchester decoding process variables
+    signal rx_manchester_input : std_logic;
+    signal rx_manchester_input_prev : std_logic;
+    signal rx_manchester_timer : std_logic_vector(31 downto 0);
+    signal rx_manchester_recovery_clk : std_logic;
+    signal rx_manchester_bit : std_logic;
+    signal rx_manchester_clk : std_logic;
+
+
+    --hdlc decoding process variables
+    type hdlc_states is (hdlc_idle, hdlc_starting, hdlc_running, hdlc_complete, hdlc_error);
+    signal hdlc_state : hdlc_states;
+    signal hdlc_unstuff_counter : std_logic_vector(2 downto 0);
+    signal hdlc_buffer : std_logic_vector(7 downto 0);
+    signal hdlc_clk : std_logic;
+    signal hdlc_bit : std_logic;
+
+
+    signal crc : std_logic_vector(15 downto 0);
+    signal crc_count : std_logic_vector(7 downto 0);
+ 
+    
+
+    --number of bits receive
+    signal rx_count : std_logic_vector(7 downto 0);
+    signal rx_register : std_logic_vector(111 downto 0);
+
+
+    signal tx_data : std_logic_vector(39 downto 0);
+    signal tx_count : std_logic_vector(5 downto 0); --number of bits to transmit
+    signal tx_en_counter : std_logic_vector(7 downto 0); --used to time enable signal setup
+    signal tx_interval_counter : std_logic_vector(7 downto 0); --counts from N to 0. Used to control bit rate output
+    signal tx_manchester_clk : std_logic; --tracks manchester bit status to convert to manchester coding
+
+    signal timer_enable : std_logic;
+    signal timer_sel : std_logic_vector(2 downto 0);
+    signal timer : std_logic;
+    signal timer_prev : std_logic;
+
+
+    --(val >> 1)
+    function one_half(val : in std_logic_vector(7 downto 0))
+        return std_logic_vector is
+    begin
+        return ('0' & val(7 downto 1));
+    end function;
+
+    --(val >> 1) + val
+    function three_half(val : in std_logic_vector(7 downto 0))
+        return std_logic_vector is
+    begin
+        return ('0' & val(7 downto 1)) + val;
+    end function;
+
+    --(val >> 1) + (val << 1)
+    function five_half(val : in std_logic_vector(7 downto 0))
+        return std_logic_vector is
+    begin
+        return ('0' & val(7 downto 1)) + (val(6 downto 0) & '0');
+    end function;
+
+
+
+begin
+    mantrx : process(clkmed)                             
+    begin
+    
+    if rising_edge(clkmed)
+    then
+        timer_prev <= timer;
+        transmit_prev <= transmit;
+
+        case timer_sel is
+            when "000" => timer <= timers(0);
+            when "001" => timer <= timers(1);
+            when "010" => timer <= timers(2);
+            when "011" => timer <= timers(3);
+            when "100" => timer <= timers(4);
+            when others => timer <= timers(0);
+        end case;
+
+   end if;
+    end process;
+
+--decodes manchester encoded serial data from input
+rx_manchester : process(clkmed)
+begin 
+    if rising_edge(clkmed) then
+        rx_manchester_input_prev <= rxdata;
+        rx_manchester_input <= rx_manchester_input_prev;
+
+        if transmitting = '1' then
+            --reset receive data
+            rx_manchester_timer <= (others=>'0');
+            rx_manchester_recovery_clk <= '0';
+            rx_manchester_clk <= '0';
+            rx_manchester_bit <= '0';
+            busy <= '1';
+        else
+            if rx_manchester_input /= rx_manchester_input_prev then
+                rx_manchester_timer <= (others=>'0');
+   
+                if rx_manchester_timer > one_half(bitrate) then
+                    if rx_manchester_timer < three_half(bitrate) then
+                        rx_manchester_recovery_clk <= not rx_manchester_recovery_clk;
+
+                        if rx_manchester_recovery_clk = '1' then
+                            rx_manchester_clk <= '1';
+                            rx_manchester_bit <= rx_manchester_input;
+                        else
+                            rx_manchester_clk <= '0';
+                        end if;
+                    elsif rx_manchester_timer < five_half(bitrate) then
+                            rx_manchester_recovery_clk <= '1';
+                            rx_manchester_clk <= '1';
+                            rx_manchester_bit <= rx_manchester_input;
+                    else
+                        rx_manchester_clk <= '0';
+                    end if;
+                end if;
+
+            elsif rx_manchester_timer < five_half(bitrate) then
+                rx_manchester_timer <= rx_manchester_timer + 1;
+                rx_manchester_clk <= '0';
+            elsif rx_manchester_timer = five_half(bitrate) then
+                --after no more data comes in tack on an additionl 0 bit
+                rx_manchester_clk <= '1';
+                rx_manchester_bit <= '0';
+                rx_manchester_timer <= rx_manchester_timer + 1;
+                busy <= '0';
+            else
+                rx_manchester_clk <= '0';
+            end if;
+        end if; 
+    end if;
+end process;
+
+--decodes an hdlc message from manchester decoded data
+rx_decode_hdlc : process(clkmed)
+    variable hdlc_next_bit : std_logic;
+begin
+    if rising_edge(clkmed) then
+        if transmitting = '1' then
+            hdlc_state <= hdlc_idle;
+            hdlc_clk <= '0';
+            hdlc_bit <= '0';
+            hdlc_unstuff_counter <= (others=>'0');
+            hdlc_buffer <= (others=>'0');
+            any_data_received <= '0';
+        else
+            if rx_manchester_clk = '0' then
+                hdlc_clk <= '0';
+            else
+                any_data_received <= '1';
+                hdlc_next_bit := hdlc_buffer(hdlc_buffer'LEFT);
+
+                if hdlc_state = hdlc_idle and hdlc_buffer = "01111110" then
+
+                    hdlc_state <= hdlc_starting;
+                    --the single bit acts as a sentinel
+                    --this allows us to determine the buffer is full
+                    hdlc_buffer <= "0000001" & rx_manchester_bit;
+                else
+                    hdlc_buffer <= hdlc_buffer(hdlc_buffer'LEFT-1 downto 0) & rx_manchester_bit;
+
+                    if hdlc_state = hdlc_starting and hdlc_next_bit = '1' then
+                        hdlc_state <= hdlc_running;
+
+                    elsif hdlc_state = hdlc_running then
+
+                        if hdlc_buffer = "01111110" then
+                            hdlc_state <= hdlc_complete;
+                        elsif hdlc_next_bit = '0' then
+                            hdlc_unstuff_counter <= (others=>'0');
+                            
+                            if hdlc_unstuff_counter < 5 then
+                                hdlc_clk <= '1';
+                                hdlc_bit <= '0';
+
+                            elsif hdlc_unstuff_counter > 5 then
+                                hdlc_state <= hdlc_error;
+                            end if;
+                        else
+                            hdlc_clk <= '1';
+                            hdlc_bit <= '1';
+                            hdlc_unstuff_counter <= hdlc_unstuff_counter + 1;  
+                        end if;
+                    end if;
+                end if;
+            end if;
+        end if;
+    end if;
+end process;
+
+
+--copies hdlc decoded data into rx_register
+rx_decode : process(clkmed)
+begin
+    if rising_edge(clkmed) then
+        if transmitting = '1' then
+            rx_register <= (others => '0');
+            rx_count <= (others => '0');
+        end if;
+
+        if hdlc_clk = '1' then
+            rx_register <= rx_register(rx_register'LEFT-1 downto 0) & hdlc_bit;
+            rx_count <= rx_count + 1;
+        end if;
+
+
+        if crc = rx_register(15 downto 0) then
+            rx_ok <= '1';
+        else
+            rx_ok <= '0';
+        end if;
+
+    end if;
+end process;
+
+--calculates crc value of the first 12 bytes of incoming hdlc decoded data
+rx_crc : process(clkmed)
+begin
+    if rising_edge(clkmed) then
+        if transmitting = '1' then
+            crc <= x"FFFF";
+            crc_count <= (others => '0');
+        elsif hdlc_clk = '1' then
+
+            if crc_count < 96 then
+                crc(0)  <= hdlc_bit xor crc(15);
+                crc(1)  <= crc(0);
+                crc(2)  <= crc(1);
+                crc(3)  <= crc(2);
+                crc(4)  <= crc(3);
+                crc(5)  <= hdlc_bit xor crc(4) xor crc(15);
+                crc(6)  <= crc(5);
+                crc(7)  <= crc(6);
+                crc(8)  <= crc(7);
+                crc(9)  <= crc(8);
+                crc(10) <= crc(9);
+                crc(11) <= crc(10);
+                crc(12) <= hdlc_bit xor crc(11) xor crc(15);
+                crc(13) <= crc(12);
+                crc(14) <= crc(13);
+                crc(15) <= crc(14);
+
+                crc_count <= crc_count + 1;
+
+            elsif crc_count = 96 then
+                crc <= crc xor x"FFFF";
+                crc_count <= crc_count + 1;
+            end if;
+        end if;
+    end if;
+end process;
+                
+                
+
+--transmits manchester encoded data over tx
+tx_manchester : process(clkmed)
+begin 
+    if rising_edge(clkmed) then
+        if enable = '1' and
+           ((transmit /= transmit_prev) or
+           (timer_enable = '1' and timer_prev = '0' and timer = '1')) then
+            transmitting <= '1';        
+        end if;
+ 
+        if transmitting  = '0' then
+            --during recieve we can prepare for a tx
+            tx_en_counter <= (others=>'0');
+            tx_interval_counter <= (others=>'0');
+            tx_manchester_clk <= '1';
+            tx_data <= x"abf7df7d7e"; --hdlc encoded value of FFFF
+            tx_count <= "101000"; --40 bits to transmit
+            txen <= '0';
+        else
+            --assert txenable
+            txen <= '1'; 
+           
+            --transmits data in tx_data register
+            --trasnmits from MSB to LSB
+            --converts to manchester code
+            --mapping is 0 -> 01
+            --           1 -> 10
+            if tx_count /= 0 then
+                if tx_en_counter < bitrate then
+                    --make sure that txen is asserted
+                    --prior to sending data
+                    tx_en_counter <= tx_en_counter + 1;
+                else
+                    if tx_interval_counter /= 0 then
+                        tx_interval_counter <= tx_interval_counter - 1;
+                    else
+                        if tx_manchester_clk = '1' then
+                            txdata <= tx_data(tx_data'LEFT);
+                        else
+                            txdata <= not tx_data(tx_data'LEFT);
+                            tx_data <= tx_data(tx_data'LEFT-1 downto 0) & '0';
+                            tx_count <= tx_count - 1;
+                        end if;
+                        
+                        tx_manchester_clk <= not tx_manchester_clk;
+                        tx_interval_counter <= bitrate;
+                    end if;
+                end if;
+            else
+                if tx_en_counter /= 0 then
+                    --make sure txen is asserted for one bitperiod 
+                    --after data is sent
+                    tx_en_counter <= tx_en_counter - 1;
+                else
+                    transmitting <= '0';
+                end if;
+            end if;
+        end if;
+    end if;
+end process; 
+
+load : process(clklow)
+    begin
+        if rising_edge(clklow) then
+            if bus_load_control = '1' then
+                enable <= ibus(0);
+                transmit <= ibus(1);
+                timer_enable <= ibus(2);
+                timer_sel <= ibus(10 downto 8);
+           end if;
+        end if;
+end process;
+
+
+store : process(clklow)
+
+    begin
+        if falling_edge(clklow) then
+            obus<= (others=>'Z');
+            
+            if bus_store_rx0 = '1' then
+                obus <= rx_register(rx_register'LEFT downto rx_register'LEFT-31);
+            end if;
+
+            if bus_store_rx1 = '1' then
+                obus <= rx_register(rx_register'LEFT-32 downto rx_register'LEFT-63);
+            end if;
+
+            if bus_store_rx2 = '1' then
+                obus <= rx_register(rx_register'LEFT-64 downto rx_register'LEFT-95);
+            end if;
+
+            if bus_store_status = '1' then
+                obus <= (0=>enable,
+                         1=>transmit,
+                         2=>timer_enable,
+                         3=>rx_ok,
+                         4=>busy,
+                         5=>any_data_received,
+                         others =>'0');
+
+                obus(10 downto 8) <= timer_sel;
+
+                obus(31 downto 16) <= crc;
+            end if;
+        end if;
+    end process;
+end Behavioral;


### PR DESCRIPTION
Yaskawa Sigma 5 encoders communicate over a 2 wire bi-directional serial connection. (RS-485)

The format of the message is an hdlc encoded message over a manchester coded signal.

The Sigma5Enc module sends a request to the serial encoder and then decodes the response and
verifies the data via CRC checksum.

Currently a single bitfile (PIN_7I74_SIGMA_34.vhd) will configure a 5i25 connected to a 7I74 to communicate with 4 SSerial devices
and 4 Sigma 5 Encoders. The Sigma5ENC modules must be interfaced with RS-485/RS-422 Adaptors. A Single TXEN pin from Sigma5Enc module 0 to all
of the adaptors allows each Sigma5 module to communicate with its respective encoder. All Sigma5Enc modules must be configured by the host to trigger at the same time.

See linuxcnc hostmot2 documentation for more information on how to use Sigma 5 Encoders.